### PR TITLE
Delete method + maintanance commandline.

### DIFF
--- a/apifiles3.py
+++ b/apifiles3.py
@@ -198,6 +198,15 @@ def remove_temp_taric_file(seq):
     session().delete_object(Bucket=AWS_BUCKET_NAME, Key=filename)
 
 
+def remove_taric_file(seq):
+    """In ordinary operation taric files are not removed, but occasionally
+    this is required.
+    """
+    filename = get_taric_filepath(seq)
+    logger.debug("Removing file %s", filename)
+    session().delete_object(Bucket=AWS_BUCKET_NAME, Key=filename)
+
+
 def rename_file(fromname, toname):
     # AWS S3 has no rename - have to copy & delete
     logger.debug("Renaming file from %s to %s", fromname, toname)

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ curl --form file=@/users/dave/downloads/Taric3_files/TGB18146.xml -H "X-API-KEY:
 
 The API is readable publicly without authentication.
 
-An API key (`X-API-KEY`) is required to upload new files. Access to the upload API endpoint is restricted to a set of whitelisted IPs both by the app and by an IP filtering route service.
+An API key (`X-API-KEY`) is required to upload new files.
 
 
 # Installation
@@ -76,9 +76,7 @@ API_ROOT            | URL prefix for serving files
 TARIC_FILES_FOLDER  | Location for Taric files (defaults to /)
 TARIC_FILES_INDEX   | Location of index file (defaults to /)
 API_KEYS            | Comma separated list of API keys that are SHA256 encoded
-WHITELIST           | Comma separated list of whitelisted source IP addresses **
 APIKEYS_UPLOAD      | Same as API_KEYS above - except these are the keys authorised to upload Taric files
-WHITELIST_UPLOAD    | Same as WHITELIST above - except these are the IP addresses whitelisted to upload Taric files
 AWS_BUCKET_NAME     | S3 bucket storing the Taric files ***
 AWS_ACCESS_KEY_ID   | S3 Access key
 AWS_SECRET_ACCESS_KEY   | S3 Secret

--- a/taricapi.py
+++ b/taricapi.py
@@ -515,7 +515,8 @@ def get_server():
 
 @click.command()
 def serve():
-    # For backwards compatibility, run the webserver by default.
+    """Run webserver.
+    """
     rebuild_index(False)
     server = get_server()
 
@@ -546,6 +547,7 @@ def ls():
 
 @click.command()
 def index():
+    """Rebuild file index."""
     rebuild_index(False)
 
 
@@ -570,6 +572,7 @@ def cli():
 
 
 if __name__ == "__main__":
+    # Setup maintenance commands.
     cli.add_command(rmdelta)
     cli.add_command(ls)
     cli.add_command(serve)


### PR DESCRIPTION
Add delete HTTP method for uploaders.

abd extra commandline options to manage taric files.

This came out of a requirement, we had to remove a taric delta file.

While this isn't something we would want to do in normal operation (and hence have an API for), there should be something more sane than my initial solution, which was running python code on the web server.

By default, this still runs the webserver - other maintenance commands available:

```
  index    Rebuild file index.
  ls       List delta, temporary and other files.
  rmdelta  Delta sequence number [6 digits].
  serve    Run webserver.
```