### PR TITLE
Package updates for security vulnerability fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+venv/

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,3 +5,4 @@ flake8==3.7.9
 flake8-bugbear==20.1.4
 pylint==2.5.3
 pip-tools==5.4.0
+pre-commit

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,22 +7,26 @@
 appdirs==1.4.4            # via black
 astroid==2.4.2            # via pylint
 attrs==20.3.0             # via black, flake8-bugbear
+backports.entry-points-selectable==1.1.0  # via virtualenv
 black==19.10b0            # via -r requirements-dev.in
 blinker==1.4              # via -r requirements.txt, elastic-apm, sentry-sdk
-boto3==1.9.62             # via -r requirements.txt
-botocore==1.12.253        # via -r requirements.txt, boto3, s3transfer
+boto3==1.18.33            # via -r requirements.txt
+botocore==1.21.33         # via -r requirements.txt, boto3, s3transfer
 certifi==2020.11.8        # via -r requirements.txt, elastic-apm, requests, sentry-sdk
+cfgv==3.3.1               # via pre-commit
 chardet==3.0.4            # via -r requirements.txt, requests
 click==7.0                # via -r requirements.txt, black, flask, pip-tools
-docutils==0.15.2          # via -r requirements.txt, botocore
+distlib==0.3.2            # via virtualenv
 ecs-logging==0.5.0        # via -r requirements.txt
 elastic-apm[flask]==5.10.0  # via -r requirements.txt
 entrypoints==0.3          # via flake8
+filelock==3.0.12          # via virtualenv
 flake8-bugbear==20.1.4    # via -r requirements-dev.in
 flake8==3.7.9             # via -r requirements-dev.in, flake8-bugbear
 flask==1.0.2              # via -r requirements.txt, sentry-sdk
 gevent==20.9.0            # via -r requirements.txt
 greenlet==0.4.17          # via -r requirements.txt, gevent
+identify==2.2.13          # via pre-commit
 idna==2.10                # via -r requirements.txt, requests
 ipy==0.83                 # via -r requirements.txt
 isort==4.3.21             # via pylint
@@ -33,20 +37,25 @@ lazy-object-proxy==1.4.3  # via astroid
 lxml==4.6.3               # via -r requirements.txt
 markupsafe==1.1.0         # via -r requirements.txt, jinja2
 mccabe==0.6.1             # via flake8, pylint
+nodeenv==1.6.0            # via pre-commit
 pathspec==0.8.1           # via black
 pip-tools==5.4.0          # via -r requirements-dev.in
+platformdirs==2.3.0       # via virtualenv
+pre-commit==2.14.1        # via -r requirements-dev.in
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
 pylint==2.5.3             # via -r requirements-dev.in
 python-dateutil==2.8.1    # via -r requirements.txt, botocore
+pyyaml==5.4.1             # via pre-commit
 regex==2020.11.13         # via black
 requests==2.25.0          # via -r requirements.txt
-s3transfer==0.1.13        # via -r requirements.txt, boto3
+s3transfer==0.5.0         # via -r requirements.txt, boto3
 sentry-sdk[flask]==0.19.4  # via -r requirements.txt
-six==1.15.0               # via -r requirements.txt, astroid, pip-tools, python-dateutil
-toml==0.10.2              # via black, pylint
+six==1.15.0               # via -r requirements.txt, astroid, pip-tools, python-dateutil, virtualenv
+toml==0.10.2              # via black, pre-commit, pylint
 typed-ast==1.4.1          # via black
-urllib3==1.25.11          # via -r requirements.txt, botocore, elastic-apm, requests, sentry-sdk
+urllib3==1.26.6           # via -r requirements.txt, botocore, elastic-apm, requests, sentry-sdk
+virtualenv==20.7.2        # via pre-commit
 werkzeug==0.15.5          # via -r requirements.txt, flask
 wrapt==1.12.1             # via astroid
 zope.event==4.5.0         # via -r requirements.txt, gevent

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-Boto3==1.9.62
+Boto3==1.18.33
 Click==7.0
 ecs-logging==0.5.0
 elastic-apm[flask]==5.10.0
@@ -12,3 +12,4 @@ MarkupSafe==1.1.0
 Werkzeug==0.15.5
 sentry-sdk[flask]==0.19.4
 requests==2.25.0
+urllib3==1.26.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,11 @@
 #    pip-compile requirements.in
 #
 blinker==1.4              # via elastic-apm, sentry-sdk
-boto3==1.9.62             # via -r requirements.in
-botocore==1.12.253        # via boto3, s3transfer
+boto3==1.18.33            # via -r requirements.in
+botocore==1.21.33         # via boto3, s3transfer
 certifi==2020.11.8        # via elastic-apm, requests, sentry-sdk
 chardet==3.0.4            # via requests
 click==7.0                # via -r requirements.in, flask
-docutils==0.15.2          # via botocore
 ecs-logging==0.5.0        # via -r requirements.in
 elastic-apm[flask]==5.10.0  # via -r requirements.in
 flask==1.0.2              # via -r requirements.in, sentry-sdk
@@ -25,10 +24,10 @@ lxml==4.6.3               # via -r requirements.in
 markupsafe==1.1.0         # via -r requirements.in, jinja2
 python-dateutil==2.8.1    # via botocore
 requests==2.25.0          # via -r requirements.in
-s3transfer==0.1.13        # via boto3
+s3transfer==0.5.0         # via boto3
 sentry-sdk[flask]==0.19.4  # via -r requirements.in
 six==1.15.0               # via python-dateutil
-urllib3==1.25.11          # via botocore, elastic-apm, requests, sentry-sdk
+urllib3==1.26.6           # via -r requirements.in, botocore, elastic-apm, requests, sentry-sdk
 werkzeug==0.15.5          # via -r requirements.in, flask
 zope.event==4.5.0         # via gevent
 zope.interface==5.2.0     # via gevent


### PR DESCRIPTION
Bumped version of Boto3 and added urllib3 as a top-level package requirement in requirement.in to address security vulnerability in urllib3 (see https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33503). Related requirements files have been generated using pip-compile.
