### PR TITLE
bump gevent to 21.8.0 to avoid cython error, bump greenlet to lowest …

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -62,9 +62,9 @@ flask==1.0.2
     # via
     #   -r requirements.txt
     #   sentry-sdk
-gevent==20.9.0
+gevent==21.8.0
     # via -r requirements.txt
-greenlet==0.4.17
+greenlet==1.1.0
     # via
     #   -r requirements.txt
     #   gevent

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ Click==7.0
 ecs-logging==0.5.0
 elastic-apm[flask]==5.10.0
 Flask==1.0.2
-gevent==20.9.0
+gevent==21.8.0
 IPy==0.83
 itsdangerous==1.1.0
 Jinja2==2.11.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,9 +35,9 @@ flask==1.0.2
     # via
     #   -r requirements.in
     #   sentry-sdk
-gevent==20.9.0
+gevent==21.8.0
     # via -r requirements.in
-greenlet==0.4.17
+greenlet==1.1.0
     # via gevent
 idna==2.10
     # via requests


### PR DESCRIPTION
…version supported by gevent

Currently it's not possible to build the project locally, either by using Docker or by manually installing requirements because of [this issue](https://github.com/gevent/gevent/issues/1801)

This PR bumps gevent to a version that support cython and accordingly bumps greenlet to support the change https://www.gevent.org/changelog.html#id2