### PR TITLE
Bump versions of urllib3 and gevent.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,8 +19,8 @@ elastic-apm[flask]==5.10.0  # via -r requirements.txt
 flake8-bugbear==23.2.13   # via -r requirements-dev.in
 flake8==6.0.0             # via -r requirements-dev.in, flake8-bugbear
 flask==2.2.5              # via -r requirements.txt, sentry-sdk
-gevent==21.8.0            # via -r requirements.txt
-greenlet==1.1.0           # via -r requirements.txt, gevent
+gevent==23.9.1            # via -r requirements.txt
+greenlet==3.0.0           # via -r requirements.txt, gevent
 idna==2.10                # via -r requirements.txt, requests
 importlib-metadata==6.8.0  # via -r requirements.txt, flask
 ipy==0.83                 # via -r requirements.txt
@@ -48,7 +48,7 @@ six==1.15.0               # via -r requirements.txt, pip-tools, python-dateutil
 tomli==2.0.1              # via black, pylint
 tomlkit==0.11.6           # via pylint
 typing-extensions==4.7.1  # via astroid, black, pylint
-urllib3==1.26.5           # via -r requirements.txt, botocore, elastic-apm, requests, sentry-sdk
+urllib3==1.26.18          # via -r requirements.txt, botocore, elastic-apm, requests, sentry-sdk
 werkzeug==2.2.3           # via -r requirements.txt, flask
 wrapt==1.15.0             # via astroid
 zipp==3.16.2              # via -r requirements.txt, importlib-metadata

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ click==8.1.3
 ecs-logging==0.5.0
 elastic-apm[flask]==5.10.0
 Flask==2.2.5
-gevent==21.8.0
+gevent==23.9.1
 IPy==0.83
 itsdangerous==2.1.2
 Jinja2==3.1.2
@@ -13,3 +13,4 @@ MarkupSafe==2.1.2
 Werkzeug==2.2.3
 sentry-sdk[flask]==0.19.4
 requests==2.31.0
+urllib3==1.26.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@ click==8.1.3              # via -r requirements.in, flask
 ecs-logging==0.5.0        # via -r requirements.in
 elastic-apm[flask]==5.10.0  # via -r requirements.in
 flask==2.2.5              # via -r requirements.in, sentry-sdk
-gevent==21.8.0            # via -r requirements.in
-greenlet==1.1.0           # via gevent
+gevent==23.9.1            # via -r requirements.in
+greenlet==3.0.0           # via gevent
 idna==2.10                # via requests
 importlib-metadata==6.8.0  # via flask
 ipy==0.83                 # via -r requirements.in
@@ -28,7 +28,7 @@ requests==2.31.0          # via -r requirements.in
 s3transfer==0.4.2         # via boto3
 sentry-sdk[flask]==0.19.4  # via -r requirements.in
 six==1.15.0               # via python-dateutil
-urllib3==1.26.5           # via botocore, elastic-apm, requests, sentry-sdk
+urllib3==1.26.18          # via -r requirements.in, botocore, elastic-apm, requests, sentry-sdk
 werkzeug==2.2.3           # via -r requirements.in, flask
 zipp==3.16.2              # via importlib-metadata
 zope.event==5.0           # via gevent


### PR DESCRIPTION
Bump versions of urllib3 and gevent to resolve alerts. Related tickets:
https://uktrade.atlassian.net/browse/TP2000-1087
https://uktrade.atlassian.net/browse/TP2000-1088

Note that this PR replaces the Dependabot-generated PRs that don't correctly upgrade the `requirements.in` and `requirements-dev.txt` files.