### PR TITLE
Update Paas Unbuntu

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
-- name: tariffs-api
-  memory: 1GB
-  buildpack: python_buildpack
+  - name: tariffs-api
+    memory: 1GB
+    buildpack: python_buildpack
+    stack: cflinuxfs4


### PR DESCRIPTION
#[TP2000-1082](https://uktrade.atlassian.net/browse/TP2000-1082) Update Paas Unbuntu

Why
[GOV.UK](http://gov.uk/) PaaS with SRE assistance are upgrading the version of Ubuntu used across applications and services. The change moves the PaaS platform from a [Ubuntu 18.04-based stack (cflinuxfs3)](https://github.com/cloudfoundry/cflinuxfs3) to [Ubuntu 22.04-based stack (cflinuxfs4)](https://github.com/cloudfoundry/cflinuxfs4).

What
This PR specifies the stack in the manifest.yml file to determine which version of cflinuxfs we should be using

Checklist
Requires migrations? - no
Requires dependency updates? - no

[TP2000-1082]: https://uktrade.atlassian.net/browse/TP2000-1082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ