### PR TITLE
Bump Jinja2 version in .in and generate .txt files.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ importlib-metadata==6.8.0  # via -r requirements.txt, flask
 ipy==0.83                 # via -r requirements.txt
 isort==4.3.21             # via pylint
 itsdangerous==2.1.2       # via -r requirements.txt, flask
-jinja2==3.1.2             # via -r requirements.txt, flask
+jinja2==3.1.3             # via -r requirements.txt, flask
 jmespath==0.10.0          # via -r requirements.txt, boto3, botocore
 lazy-object-proxy==1.4.3  # via astroid
 lxml==4.9.1               # via -r requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ Flask==2.2.5
 gevent==23.9.1
 IPy==0.83
 itsdangerous==2.1.2
-Jinja2==3.1.2
+Jinja2==3.1.3
 lxml==4.9.1
 MarkupSafe==2.1.2
 Werkzeug==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ idna==2.10                # via requests
 importlib-metadata==6.8.0  # via flask
 ipy==0.83                 # via -r requirements.in
 itsdangerous==2.1.2       # via -r requirements.in, flask
-jinja2==3.1.2             # via -r requirements.in, flask
+jinja2==3.1.3             # via -r requirements.in, flask
 jmespath==0.10.0          # via boto3, botocore
 lxml==4.9.1               # via -r requirements.in
 markupsafe==2.1.2         # via -r requirements.in, jinja2, werkzeug


### PR DESCRIPTION
Bumps [Jinja2](https://github.com/pallets/jinja/) from version 3.1.2 to 3.1.3 in `requirements.in` with accompanying (pip-compile generated) updates to `requirements.txt` and `requirements-dev.txt`.