### PR TITLE
TP2000-1293 Bump Black to fix security issue.

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-black==23.1.0
+black==24.3.0
 flake8==6.0.0
 flake8-bugbear==23.2.13
 pylint==2.16.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 astroid==2.14.2           # via pylint
 attrs==20.3.0             # via flake8-bugbear
-black==23.1.0             # via -r requirements-dev.in
+black==24.3.0             # via -r requirements-dev.in
 blinker==1.4              # via -r requirements.txt, elastic-apm, sentry-sdk
 boto3==1.17.97            # via -r requirements.txt
 botocore==1.20.97         # via -r requirements.txt, boto3, s3transfer


### PR DESCRIPTION
# TP2000-1293 Bump Black to fix security issue

Black vulnerable to Regular Expression Denial of Service:
https://github.com/uktrade/trade-tariff-api/security/dependabot/39

Dependabot is unable to generate a requirements fix because the repo uses pip compile. This is therefore a manually created fix.