### PR TITLE
Bump idna version, add pipdeptree.

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,4 +4,5 @@ black==24.3.0
 flake8==6.0.0
 flake8-bugbear==23.2.13
 pylint==2.16.3
+pipdeptree==2.15.1
 pip-tools==5.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,7 +21,7 @@ flake8==6.0.0             # via -r requirements-dev.in, flake8-bugbear
 flask==2.2.5              # via -r requirements.txt, sentry-sdk
 gevent==23.9.1            # via -r requirements.txt
 greenlet==3.0.0           # via -r requirements.txt, gevent
-idna==2.10                # via -r requirements.txt, requests
+idna==3.7                 # via -r requirements.txt, requests
 importlib-metadata==6.8.0  # via -r requirements.txt, flask
 ipy==0.83                 # via -r requirements.txt
 isort==4.3.21             # via pylint
@@ -36,6 +36,7 @@ mypy-extensions==1.0.0    # via black
 packaging==23.1           # via black
 pathspec==0.11.0          # via black
 pip-tools==5.4.0          # via -r requirements-dev.in
+pipdeptree==2.15.1        # via -r requirements-dev.in
 platformdirs==3.0.0       # via black, pylint
 pycodestyle==2.10.0       # via flake8
 pyflakes==3.0.1           # via flake8

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ ecs-logging==0.5.0
 elastic-apm[flask]==5.10.0
 Flask==2.2.5
 gevent==23.9.1
+idna==3.7
 IPy==0.83
 itsdangerous==2.1.2
 Jinja2==3.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ elastic-apm[flask]==5.10.0  # via -r requirements.in
 flask==2.2.5              # via -r requirements.in, sentry-sdk
 gevent==23.9.1            # via -r requirements.in
 greenlet==3.0.0           # via gevent
-idna==2.10                # via requests
+idna==3.7                 # via -r requirements.in, requests
 importlib-metadata==6.8.0  # via flask
 ipy==0.83                 # via -r requirements.in
 itsdangerous==2.1.2       # via -r requirements.in, flask


### PR DESCRIPTION
Internationalized Domain Names in Applications (IDNA) vulnerable to denial of service from specially crafted inputs to idna.encode.

Also include pipdeptools as part of development requirements (via `requirements-dev.in`) in order to identify which package is dependent upon idna, since it wasn't directly included as a direct requirement in `requirement.in`.

Dependabot is unable to generate a requirements fix because the repo uses pip compile. This is therefore a manually created fix.