### PR TITLE
TP2000-1346 Bump werkzeug version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -50,7 +50,7 @@ tomli==2.0.1              # via black, pylint
 tomlkit==0.11.6           # via pylint
 typing-extensions==4.8.0  # via astroid, black, pylint
 urllib3==1.26.18          # via -r requirements.txt, botocore, elastic-apm, requests, sentry-sdk
-werkzeug==3.0.1           # via -r requirements.txt, flask
+werkzeug==3.0.3           # via -r requirements.txt, flask
 wrapt==1.15.0             # via astroid
 zipp==3.17.0              # via -r requirements.txt, importlib-metadata
 zope.event==5.0           # via -r requirements.txt, gevent

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ itsdangerous==2.1.2
 Jinja2==3.1.3
 lxml==4.9.1
 MarkupSafe==2.1.2
-Werkzeug==3.0.1
-sentry-sdk[flask]==0.19.4
 requests==2.31.0
+sentry-sdk[flask]==0.19.4
 urllib3==1.26.18
+Werkzeug==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ s3transfer==0.4.2         # via boto3
 sentry-sdk[flask]==0.19.4  # via -r requirements.in
 six==1.15.0               # via python-dateutil
 urllib3==1.26.18          # via -r requirements.in, botocore, elastic-apm, requests, sentry-sdk
-werkzeug==3.0.1           # via -r requirements.in, flask
+werkzeug==3.0.3           # via -r requirements.in, flask
 zipp==3.17.0              # via importlib-metadata
 zope.event==5.0           # via gevent
 zope.interface==6.1       # via gevent


### PR DESCRIPTION
# TP2000-1346 Bump werkzeug version

Werkzeug vulnerability fix.

Dependabot is unable to generate a requirements fix because the repo uses pip compile. This is therefore a manually created fix.