### PR TITLE
TP2000-1339 Create staging service integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 
 # Environments
 .env
+.env.*
 .venv
 env/
 venv*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,14 +10,14 @@ RUN \
 # Create app directory
 WORKDIR /app
 
-# Install app dependencies
+# Install Python package dependencies.
+COPY requirements*.txt /app/
+RUN pip install --upgrade pip setuptools
+RUN pip install -r requirements.txt --no-warn-script-location
+
+# Copy app source code.
 COPY . /app
 
-RUN pip install \
-    -U pip setuptools \
-    -r requirements.txt
-
 EXPOSE 8080
-
 CMD /bin/s -c source docker-helpers/whitelist-host-ips \
     python taricapi.py

--- a/config.py
+++ b/config.py
@@ -23,6 +23,8 @@ APIKEYS_UPLOAD = strtolist(os.environ.get("APIKEYS_UPLOAD"))
 TARIC_FILES_FOLDER = os.environ.get("TARIC_FILES_FOLDER", "taricfiles")
 TARIC_FILES_INDEX = os.environ.get("TARIC_FILES_INDEX", "taricdeltas.json")
 
+TARICAPI_LOG_LEVEL = os.environ.get("TARICAPI_LOG_LEVEL", "INFO")
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -39,7 +41,7 @@ LOGGING = {
         }
     },
     "root": {"level": "INFO", "handlers": ["wsgi"]},
-    "taricapi": {"level": "INFO", "handlers": ["wsgi"]},
+    "taricapi": {"level": TARICAPI_LOG_LEVEL, "handlers": ["wsgi"]},
     "flask": {"level": "INFO", "handlers": ["wsgi"]},
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,15 +24,18 @@ services:
       - tariff-api-s3
     environment:
       ENVIRONMENT: "development"
+      TARICAPI_LOG_LEVEL: "DEBUG"
       PORT: "8080"
       AWS_ACCESS_KEY_ID: "minio_access_key"
       AWS_SECRET_ACCESS_KEY: "minio_secret_key"
       AWS_BUCKET_NAME: "tariff-api-bucket"
       S3_ENDPOINT_URL: "http://tariff-api-s3:9004"
-      # abc123, def456
-      APIKEYS: "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090,
-8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587"
-      # def456
+      # APIKEYS is actually a list of SHA256 hashes of keys (abc123 and def456,
+      # respectively here, used only for local tests) - the non-hashed key value
+      # is used in the X-API-KEY header of test client REST API calls, but
+      # loaded into the service on startup in its hashed form.
+      APIKEYS: "6ca13d52ca70c883e0f0bb101e425a89e8624de51db2d2392593af6a84118090,8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587"
+      # Ditto APIKEYS for APIKEYS_UPLOAD (def456 being non-hashed key value).
       APIKEYS_UPLOAD: "8f61ad5cfa0c471c8cbf810ea285cb1e5f9c2c5e5e5e4f58a3229667703e1587"
       WHITELIST: 1.2.3.4
       WHITELIST_UPLOAD: 1.2.3.4

--- a/generate_api_key.py
+++ b/generate_api_key.py
@@ -40,7 +40,7 @@ def generate_keys(api_key: str=None) -> tuple[str, str]:
 
 @click.group(invoke_without_command=True)
 @click.pass_context
-@click.option("--api_key", required=False, help="Provide a key a hashing.")
+@click.option("--api_key", required=False, help="Provide a key for hashing.")
 def cli(ctx, api_key):
     """Generate and print an API key and its hash."""
 

--- a/generate_api_key.py
+++ b/generate_api_key.py
@@ -1,20 +1,52 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import uuid
 import hashlib
+import click
 
 
-apikey = uuid.uuid4()
+def print_keys(api_key, hashed_api_key) -> None:
+    """Print `api_key` and `hashed_api_key` to the console with an informational
+    message."""
 
-print("Provide the key below to the client")
-print("================================")
-print(apikey.hex)
-print("================================")
+    click.echo()
+    click.echo("Provide the key to the client:")
+    click.secho(api_key.decode("utf-8"), bold=True)
+    click.echo()
+    click.echo("Store the key's hash as an APIKEYS / APIKEYS_UPLOAD env var:")
+    click.secho(hashed_api_key, bold=True)
+    click.echo()
 
-print("\nStore the hashed key below in the APIKEYS environment variable")
-# generate a hash for the key
-hp = hashlib.sha256(apikey.hex.encode("ascii")).hexdigest()
 
-print("================================================================")
-print(hp)
-print("================================================================")
+def generate_keys(api_key: str=None) -> tuple[str, str]:
+    """Generate an API key and its hash, returning both in that order within a
+    tuple. If `api_key` is provided (it must be a hex value in string format)
+    then its value is used as the API key from which the hash is generated."""
+
+    if api_key:
+        try:
+            int(api_key, 16)
+        except ValueError:
+            click.secho("Error: api_key must be a hexadecimal value.", fg="red")
+            exit(1)
+        api_key = api_key.encode("ascii")
+    else:
+        api_key = uuid.uuid4().hex.encode("ascii")
+
+    hashed_api_key = hashlib.sha256(api_key).hexdigest()
+
+    return api_key, hashed_api_key
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+@click.option("--api_key", required=False, help="Provide a key a hashing.")
+def cli(ctx, api_key):
+    """Generate and print an API key and its hash."""
+
+    api_key, hashed_api_key = generate_keys(api_key)
+    print_keys(api_key, hashed_api_key)
+
+
+if __name__ == "__main__":
+    cli()

--- a/generate_api_key.py
+++ b/generate_api_key.py
@@ -18,7 +18,7 @@ def print_keys(api_key, hashed_api_key) -> None:
     click.echo()
 
 
-def generate_keys(api_key: str=None) -> tuple[str, str]:
+def generate_keys(api_key: str = None) -> tuple[str, str]:
     """Generate an API key and its hash, returning both in that order within a
     tuple. If `api_key` is provided (it must be a hex value in string format)
     then its value is used as the API key from which the hash is generated."""

--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,23 @@ against staging (replace `<api_key> with appropropriate values from the secrets 
     curl -H "X-API-KEY: <api_key>" -X POST https://tariffs-api-staging.london.cloudapps.digital/api/v1/rebuildindex
 
 
+# Integration testing
+
+Integration tests may be executed against services instance by creating and
+configuring a `.env` file in the `/test_integration` directory and then
+executing them via pytest:
+
+    pytest --env-file=.env test_integration
+
+See the file `/test_integration/example.env` for an example `.env` file.
+Multiple `.env` files may be configured in this way to allow pointing at
+different `.env` files, each containing settings for its specific service
+instance.
+
+Note that because tests may have enduring side-effects (if one of the tests
+fails), they probably shouldn't be run against a production service.
+
+
 # Further detail
 
 The complete API specification is documented and available in separate word documentation.

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -3,6 +3,8 @@
 black==24.3.0
 flake8==6.0.0
 flake8-bugbear==23.2.13
-pylint==2.16.3
-pipdeptree==2.15.1
 pip-tools==5.4.0
+pipdeptree==2.15.1
+pylint==2.16.3
+pytest-playwright==0.4.4
+python-dotenv==1.0.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,13 +16,15 @@ click==8.1.3              # via -r requirements.txt, black, flask, pip-tools
 dill==0.3.6               # via pylint
 ecs-logging==0.5.0        # via -r requirements.txt
 elastic-apm[flask]==5.10.0  # via -r requirements.txt
+exceptiongroup==1.2.1     # via pytest
 flake8-bugbear==23.2.13   # via -r requirements-dev.in
 flake8==6.0.0             # via -r requirements-dev.in, flake8-bugbear
 flask==2.2.5              # via -r requirements.txt, sentry-sdk
 gevent==23.9.1            # via -r requirements.txt
-greenlet==3.0.0           # via -r requirements.txt, gevent
+greenlet==3.0.3           # via -r requirements.txt, gevent, playwright
 idna==3.7                 # via -r requirements.txt, requests
 importlib-metadata==6.8.0  # via -r requirements.txt, flask
+iniconfig==2.0.0          # via pytest
 ipy==0.83                 # via -r requirements.txt
 isort==4.3.21             # via pylint
 itsdangerous==2.1.2       # via -r requirements.txt, flask
@@ -33,20 +35,29 @@ lxml==4.9.1               # via -r requirements.txt
 markupsafe==2.1.2         # via -r requirements.txt, jinja2, werkzeug
 mccabe==0.7.0             # via flake8, pylint
 mypy-extensions==1.0.0    # via black
-packaging==23.1           # via black
+packaging==23.1           # via black, pytest
 pathspec==0.11.0          # via black
 pip-tools==5.4.0          # via -r requirements-dev.in
 pipdeptree==2.15.1        # via -r requirements-dev.in
 platformdirs==3.0.0       # via black, pylint
+playwright==1.43.0        # via pytest-playwright
+pluggy==1.5.0             # via pytest
 pycodestyle==2.10.0       # via flake8
+pyee==11.1.0              # via playwright
 pyflakes==3.0.1           # via flake8
 pylint==2.16.3            # via -r requirements-dev.in
-python-dateutil==2.8.1    # via -r requirements.txt, botocore
-requests==2.31.0          # via -r requirements.txt
+pytest-base-url==2.1.0    # via pytest-playwright
+pytest-playwright==0.4.4  # via -r requirements-dev.in
+pytest==8.2.0             # via pytest-base-url, pytest-playwright
+python-dateutil==2.9.0.post0  # via -r requirements.txt, botocore
+python-dotenv==1.0.1      # via -r requirements-dev.in
+python-slugify==8.0.4     # via pytest-playwright
+requests==2.31.0          # via -r requirements.txt, pytest-base-url
 s3transfer==0.4.2         # via -r requirements.txt, boto3
 sentry-sdk[flask]==0.19.4  # via -r requirements.txt
 six==1.15.0               # via -r requirements.txt, pip-tools, python-dateutil
-tomli==2.0.1              # via black, pylint
+text-unidecode==1.3       # via python-slugify
+tomli==2.0.1              # via black, pylint, pytest
 tomlkit==0.11.6           # via pylint
 typing-extensions==4.8.0  # via astroid, black, pylint
 urllib3==1.26.18          # via -r requirements.txt, botocore, elastic-apm, requests, sentry-sdk

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -80,7 +80,7 @@ pytest==8.2.0             # via pytest-base-url, pytest-playwright
 python-dateutil==2.9.0.post0  # via -r requirements.txt, botocore, celery
 python-dotenv==1.0.1      # via -r requirements-dev.in
 python-slugify==8.0.4     # via pytest-playwright
-requests==2.31.0          # via -r requirements.txt, dbt-copilot-python, opentelemetry-exporter-otlp-proto-http
+requests==2.31.0          # via -r requirements.txt, dbt-copilot-python, opentelemetry-exporter-otlp-proto-http, pytest-base-url
 s3transfer==0.4.2         # via -r requirements.txt, boto3
 sentry-sdk[flask]==0.19.4  # via -r requirements.txt
 six==1.15.0               # via -r requirements.txt, pip-tools, python-dateutil

--- a/requirements.in
+++ b/requirements.in
@@ -5,13 +5,15 @@ ecs-logging==0.5.0
 elastic-apm[flask]==5.10.0
 Flask==2.2.5
 gevent==23.9.1
+greenlet==3.0.3
 idna==3.7
 IPy==0.83
 itsdangerous==2.1.2
 Jinja2==3.1.3
 lxml==4.9.1
 MarkupSafe==2.1.2
-Werkzeug==3.0.1
-sentry-sdk[flask]==0.19.4
+python-dateutil>=2.8.2
 requests==2.31.0
+sentry-sdk[flask]==0.19.4
 urllib3==1.26.18
+Werkzeug==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ opentelemetry-semantic-conventions==0.43b0  # via opentelemetry-instrumentation-
 opentelemetry-util-http==0.43b0  # via opentelemetry-instrumentation-wsgi
 prompt-toolkit==3.0.43    # via click-repl
 protobuf==4.25.3          # via googleapis-common-protos, opentelemetry-proto
-python-dateutil==2.9.0.post0  # via botocore, celery
+python-dateutil==2.9.0.post0  # via -r requirements.in, botocore, celery
 requests==2.31.0          # via -r requirements.in, dbt-copilot-python, opentelemetry-exporter-otlp-proto-http
 s3transfer==0.4.2         # via boto3
 sentry-sdk[flask]==0.19.4  # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ ecs-logging==0.5.0        # via -r requirements.in
 elastic-apm[flask]==5.10.0  # via -r requirements.in
 flask==2.2.5              # via -r requirements.in, sentry-sdk
 gevent==23.9.1            # via -r requirements.in
-greenlet==3.0.0           # via gevent
+greenlet==3.0.3           # via -r requirements.in, gevent
 idna==3.7                 # via -r requirements.in, requests
 importlib-metadata==6.8.0  # via flask
 ipy==0.83                 # via -r requirements.in
@@ -23,7 +23,7 @@ jinja2==3.1.3             # via -r requirements.in, flask
 jmespath==0.10.0          # via boto3, botocore
 lxml==4.9.1               # via -r requirements.in
 markupsafe==2.1.2         # via -r requirements.in, jinja2, werkzeug
-python-dateutil==2.8.1    # via botocore
+python-dateutil==2.9.0.post0  # via -r requirements.in, botocore
 requests==2.31.0          # via -r requirements.in
 s3transfer==0.4.2         # via boto3
 sentry-sdk[flask]==0.19.4  # via -r requirements.in

--- a/taricapi.py
+++ b/taricapi.py
@@ -448,10 +448,13 @@ def taricfiles_upload(seq):
 
     # file is that attached in the POST request
     file = request.files["file"]
-
-    if not file or file.filename == "":
-        logger.debug("No file uploaded")
+    if not file:
+        logger.debug("No file provided")
         return Response("400 No file uploaded", status=400)
+
+    if file.filename == "":
+        logger.debug("No filename")
+        return Response("400 No filename", status=400)
 
     logger.debug("file uploaded is %s", file.filename)
 

--- a/test_integration/conftest.py
+++ b/test_integration/conftest.py
@@ -1,9 +1,8 @@
-
 def pytest_addoption(parser):
     """
     Add a custom pytest option, `--env-file`, to allow different env files to be
     configured and used when running integration tests.
-    
+
     This enables support for different environment files when integration
     testing against different service environments. For instance, by creating
     the file `.env.test` we can use the env vars configured in that file instead

--- a/test_integration/conftest.py
+++ b/test_integration/conftest.py
@@ -1,0 +1,15 @@
+
+def pytest_addoption(parser):
+    """
+    Add a custom pytest option, `--env-file`, to allow different env files to be
+    configured and used when running integration tests.
+    
+    This enables support for different environment files when integration
+    testing against different service environments. For instance, by creating
+    the file `.env.test` we can use the env vars configured in that file instead
+    of those found in `.env` (the default):
+
+        pytest --env-file=.env.test
+    """
+
+    parser.addoption("--env-file", action="store", default=".env")

--- a/test_integration/example.env
+++ b/test_integration/example.env
@@ -1,0 +1,4 @@
+# Example .env file.
+
+SERVICE_BASE_URL=https://<hostname>:<port>
+SERVICE_API_KEY=<secret>

--- a/test_integration/test_service_endpoints.py
+++ b/test_integration/test_service_endpoints.py
@@ -12,7 +12,7 @@ from playwright.sync_api import Playwright
 DELTAS_URL_PATH = "/api/v1/taricdeltas"
 FILES_URL_PATH = "/api/v1/taricfiles"
 
-SEQUENCE_ID = "180251"
+SEQUENCE_ID = 180251
 ENVELOPE_FILE_NAME = "DIT123456.xml"
 MODTIME = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
 DATE = datetime.now().strftime("%Y-%m-%d")
@@ -72,8 +72,7 @@ def api_request_context(
 @pytest.fixture
 def envelope_file_content() -> str:
     """Return the contents of a valid envelope file."""
-    return (
-        """<?xml version="1.0" encoding="UTF-8"?>
+    return """<?xml version="1.0" encoding="UTF-8"?>
         <env:envelope
           xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0"
           xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0"
@@ -81,7 +80,6 @@ def envelope_file_content() -> str:
         >
         <env:transaction id="123"></env:transaction>
         </env:envelope>"""
-    )
 
 
 @pytest.fixture
@@ -166,15 +164,21 @@ def test_get_deltas(
     """Test getting a list of envelopes from the service."""
 
     response = api_request_context.get(f"{DELTAS_URL_PATH}/{DATE}")
-
     assert response.ok
+
+    deltas = response.json()
+    assert deltas[0]["id"] == SEQUENCE_ID
+    assert deltas[0]["issue_date"] == MODTIME
 
 
 def test_get_envelope(
     api_request_context: APIRequestContext,
     posted_envelope: None,
+    envelope_file_content: str,
 ):
     """Test getting a specific envelope from the service."""
 
     response = api_request_context.get(f"{FILES_URL_PATH}/{SEQUENCE_ID}")
     assert response.ok
+
+    assert response.body() == str.encode(envelope_file_content)

--- a/test_integration/test_service_endpoints.py
+++ b/test_integration/test_service_endpoints.py
@@ -5,9 +5,7 @@ import pytest
 
 from dotenv import load_dotenv
 from playwright.sync_api import APIRequestContext
-from playwright.sync_api import expect
 from playwright.sync_api import Playwright
-from playwright.sync_api import Page
 
 
 DELTAS_URL_PATH = "/api/v1/taricdeltas"
@@ -68,11 +66,14 @@ def api_request_context(
 @pytest.fixture
 def envelope_file_content():
     return (
-"""<?xml version="1.0" encoding="UTF-8"?>
-<env:envelope xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0" xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0" id="12345">
-    <env:transaction id="123">
-    </env:transaction>
-</env:envelope>"""
+        """<?xml version="1.0" encoding="UTF-8"?>
+        <env:envelope
+          xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0"
+          xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0"
+          id="12345"
+        >
+        <env:transaction id="123"></env:transaction>
+        </env:envelope>"""
     )
 
 
@@ -108,22 +109,6 @@ def test_post_envelope(
     envelope_file_content,
 ):
     """Test posting a valid envelope file to the service."""
-
-
-    """
-    Info: equivalent test taken from runtests.sh
-    ---
-    test "Correct file upload -> expect 200"
-    curl -s -i
-        -H "X-API-KEY: def456"
-        -H "X-Forwarded-For: 1.2.3.4, 127.0.0.1"
-        --form file=@tests/DIT123456.xml
-        -w "%{http_code}"
-        -o /dev/null
-        $APIURLFILE/180251?modtime=2019-02-05T12:00:00.000
-    assert "200" "$out"
-    """
-
 
     response = api_request_context.post(
         f"{FILES_URL_PATH}/180251",

--- a/test_integration/test_service_endpoints.py
+++ b/test_integration/test_service_endpoints.py
@@ -1,0 +1,88 @@
+from typing import Generator
+
+import os
+import pytest
+
+from dotenv import load_dotenv
+from playwright.sync_api import APIRequestContext
+from playwright.sync_api import expect
+from playwright.sync_api import Playwright
+from playwright.sync_api import Page
+
+
+DELTAS_URL_PATH = "/api/v1/taricdeltas"
+FILES_URL_PATH = "/api/v1/taricfiles"
+
+
+@pytest.fixture(scope="session")
+def init_from_dotenv() -> None:
+    """
+    Load config variables from a `.env` file into environment variables for use
+    by fixtures and tests.
+
+    The `.env` may be located in this module's directory or higher up the
+    application's directory hierarchy.
+    """
+    assert load_dotenv()
+
+
+@pytest.fixture(scope="session")
+def service_base_url(init_from_dotenv) -> str:
+    """Retrieve the base URL of the service under test from the
+    env var `SERVICE_BASE_URL`."""
+
+    return os.environ.get("SERVICE_BASE_URL")
+
+
+@pytest.fixture(scope="session")
+def service_api_key(init_from_dotenv) -> str:
+    """Retrieve the API key of the service under test from the env var
+    `SERVICE_API_KEY`."""
+
+    return os.environ.get("SERVICE_API_KEY")
+
+
+@pytest.fixture(scope="session")
+def api_request_context(
+    playwright: Playwright,
+    service_api_key: str,
+    service_base_url: str,
+) -> Generator[APIRequestContext, None, None]:
+    """Generator yeilding a Playwright APIRequestContext for use when calling
+    API endpoints."""
+
+    headers = {}
+    if service_api_key:
+        headers["X-API-KEY"] = service_api_key
+
+    request_context = playwright.request.new_context(
+        base_url=service_base_url,
+        extra_http_headers=headers,
+    )
+    yield request_context
+    request_context.dispose()
+
+
+def test_root_path(
+    playwright: Playwright,
+    service_base_url: str,
+):
+    """Test that the application's root path responds correctly with a
+    `200 OK` response."""
+
+    request_context = playwright.request.new_context(base_url=service_base_url)
+    response = request_context.get(url="")
+    assert response.ok
+    request_context.dispose()
+
+
+def test_fail_with_no_api_key(
+    api_request_context,
+):
+    """
+    TODO:
+
+    test "No API KEY -> expect 403"
+    out=$(curl -s -w "%{http_code}" -o /dev/null $APIURLLIST)
+    assert "403" "$out"
+    """

--- a/test_integration/test_service_endpoints.py
+++ b/test_integration/test_service_endpoints.py
@@ -70,7 +70,8 @@ def api_request_context(
 
 
 @pytest.fixture
-def envelope_file_content():
+def envelope_file_content() -> str:
+    """Return the contents of a valid envelope file."""
     return (
         """<?xml version="1.0" encoding="UTF-8"?>
         <env:envelope
@@ -85,9 +86,9 @@ def envelope_file_content():
 
 @pytest.fixture
 def posted_envelope(
-    api_request_context,
-    envelope_file_content,
-):
+    api_request_context: APIRequestContext,
+    envelope_file_content: str,
+) -> Generator[None, None, None]:
     """Post an envelope to the service. Used for tests that require an envelope to retrieve."""
     response = api_request_context.post(
         f"{FILES_URL_PATH}/{SEQUENCE_ID}",
@@ -109,7 +110,7 @@ def posted_envelope(
 
 
 def test_root_path(
-    api_request_context,
+    api_request_context: APIRequestContext,
 ):
     """Test that the application's root path responds correctly with a
     `200 OK` response."""
@@ -136,8 +137,8 @@ def test_fail_with_no_api_key(
 
 
 def test_post_envelope(
-    api_request_context,
-    envelope_file_content,
+    api_request_context: APIRequestContext,
+    envelope_file_content: str,
 ):
     """Test posting a valid envelope file to the service."""
 
@@ -159,8 +160,8 @@ def test_post_envelope(
 
 
 def test_get_deltas(
-    api_request_context,
-    posted_envelope,
+    api_request_context: APIRequestContext,
+    posted_envelope: None,
 ):
     """Test getting a list of envelopes from the service."""
 
@@ -170,8 +171,8 @@ def test_get_deltas(
 
 
 def test_get_envelope(
-    api_request_context,
-    posted_envelope,
+    api_request_context: APIRequestContext,
+    posted_envelope: None,
 ):
     """Test getting a specific envelope from the service."""
 

--- a/test_integration/test_service_endpoints.py
+++ b/test_integration/test_service_endpoints.py
@@ -167,3 +167,13 @@ def test_get_deltas(
     response = api_request_context.get(f"{DELTAS_URL_PATH}/{DATE}")
 
     assert response.ok
+
+
+def test_get_envelope(
+    api_request_context,
+    posted_envelope,
+):
+    """Test getting a specific envelope from the service."""
+
+    response = api_request_context.get(f"{FILES_URL_PATH}/{SEQUENCE_ID}")
+    assert response.ok

--- a/test_integration/test_service_endpoints.py
+++ b/test_integration/test_service_endpoints.py
@@ -116,7 +116,7 @@ def test_post_envelope(
             "modtime": "2019-02-05T12:00:00.000",
         },
         multipart={
-            "fileField": {
+            "file": {
                 "name": "DIT123456.xml",
                 "mimeType": "application/xml",
                 "buffer": str.encode(envelope_file_content),

--- a/test_integration/test_service_endpoints.py
+++ b/test_integration/test_service_endpoints.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Generator
 
 import os
@@ -10,6 +11,11 @@ from playwright.sync_api import Playwright
 
 DELTAS_URL_PATH = "/api/v1/taricdeltas"
 FILES_URL_PATH = "/api/v1/taricfiles"
+
+SEQUENCE_ID = "180251"
+ENVELOPE_FILE_NAME = "DIT123456.xml"
+MODTIME = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+DATE = datetime.now().strftime("%Y-%m-%d")
 
 
 @pytest.fixture(scope="session")
@@ -111,13 +117,13 @@ def test_post_envelope(
     """Test posting a valid envelope file to the service."""
 
     response = api_request_context.post(
-        f"{FILES_URL_PATH}/180251",
+        f"{FILES_URL_PATH}/{SEQUENCE_ID}",
         params={
-            "modtime": "2019-02-05T12:00:00.000",
+            "modtime": MODTIME,
         },
         multipart={
             "file": {
-                "name": "DIT123456.xml",
+                "name": ENVELOPE_FILE_NAME,
                 "mimeType": "application/xml",
                 "buffer": str.encode(envelope_file_content),
             },

--- a/test_integration/test_service_endpoints.py
+++ b/test_integration/test_service_endpoints.py
@@ -4,7 +4,8 @@ from typing import Generator
 import os
 import pytest
 
-from dotenv import load_dotenv
+from dotenv import find_dotenv
+from dotenv.main import DotEnv
 from playwright.sync_api import APIRequestContext
 from playwright.sync_api import Playwright
 
@@ -20,7 +21,7 @@ DATE = datetime.now().strftime("%Y-%m-%d")
 
 
 @pytest.fixture(scope="session")
-def init_from_dotenv() -> None:
+def init_from_dotenv(pytestconfig) -> None:
     """
     Load config variables from a `.env` file into environment variables for use
     by fixtures and tests.
@@ -28,7 +29,14 @@ def init_from_dotenv() -> None:
     The `.env` should be located in this module's directory.
     """
 
-    assert load_dotenv()
+    env_filename = pytestconfig.getoption("--env-file")
+    dotenv_path = find_dotenv(filename=env_filename)
+
+    assert dotenv_path
+
+    dotenv = DotEnv(dotenv_path=dotenv_path)
+
+    assert dotenv.set_as_environment_variables()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# [TP2000-1339](https://uktrade.atlassian.net/browse/TP2000-1339) Create staging service integration tests

## Why
There is currently no test capability for use against the staging (or development) environment. The tests that do exist are only usable within a development docker environment, and are insufficient for validating pending changes on DBT infrastructure.

## What
- Integrates Playwright testing framework
- Creates integration tests for the following API endpoints:
    - GET root path
    - GET deltas without API key
    - POST envelope
    - GET deltas
    - GET envelope
- Integration test configuration from `.env` file.
- Support for specifying env file name to pytest (default to `.env`) allowing multiple env files, each for different service instances.

## Checklist
- Requires dependency updates? **Yes**
---
Branch author: @paulpepper-trade 

[TP2000-1339]: https://uktrade.atlassian.net/browse/TP2000-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ