### PR TITLE
TP2000-1383 Add logging formatting tests

### DIFF
--- a/asim_formatter.py
+++ b/asim_formatter.py
@@ -52,7 +52,7 @@ class ASIMFormatter(logging.Formatter):
             "EventEndTime": log_time,
             "EventType": "HTTPsession",
             "EventSeverity": self._get_event_severity(record.levelname),
-            "EventOriginalSeverity": record.levelname,  # duplicate of above?
+            "EventOriginalSeverity": record.levelname,
             "EventSchema": "WebSession",
             "EventSchemaVersion": "0.2.6",
         }

--- a/asim_formatter.py
+++ b/asim_formatter.py
@@ -15,13 +15,12 @@ class ASIMFormatter(logging.Formatter):
 
         return event_result
 
-    def _get_file_name(self, request: Request) -> str:
-        if not request.files:
-            return "N/A"
-        if len(request.files.keys()) == 1:
-            return list(request.files.keys())[0]
+    def _get_file_name(self, response: Response) -> str:
+        content_disposition = response.headers.get("Content-Disposition")
+        if content_disposition:
+            return content_disposition.split("filename=")[-1].strip('"')
 
-        return ";".join(list(request.files.keys())[0])
+        return "N/A"
 
     def _get_event_severity(self, log_level: str) -> str:
         event_map = {
@@ -61,7 +60,6 @@ class ASIMFormatter(logging.Formatter):
             "HttpRequestXff": request.headers.get("X-Forwarded-For"),
             "HttpResponseTime": "N/A",
             "HttpHost": request.host,
-            "FileName": self._get_file_name(request),
             "AdditionalFields": {
                 "TraceHeaders": {},
             },
@@ -78,6 +76,7 @@ class ASIMFormatter(logging.Formatter):
         return {
             "EventResult": self._get_event_result(response),
             "EventResultDetails": response.status_code,
+            "FileName": self._get_file_name(response),
             "HttpStatusCode": response.status_code,
         }
 

--- a/asim_formatter.py
+++ b/asim_formatter.py
@@ -25,7 +25,8 @@ class ASIMFormatter(logging.Formatter):
     @staticmethod
     def _get_file_name_from_content_disposition(content_disposition):
         """Get the file name from the content disposition header.
-        Uses a regex string to match filenames both enclosed or not enclosed in quotes"""
+        Uses a regex string to match filenames both enclosed or not enclosed in quotes
+        """
         search_result = re.search(r"""filename="?([^";\s]+)"?""", content_disposition)
         if search_result:
             return search_result.group(1)

--- a/asim_formatter.py
+++ b/asim_formatter.py
@@ -1,8 +1,8 @@
 import json
 import logging
 import os
+import re
 from datetime import datetime
-
 from flask import Request
 from flask import Response
 from flask import has_request_context
@@ -18,13 +18,19 @@ class ASIMFormatter(logging.Formatter):
     def _get_file_name(self, response: Response) -> str:
         content_disposition = response.headers.get("Content-Disposition")
         if content_disposition:
-            search_result = re.search("filename=(.*)[;]", content_disposition)
-            if search_result:
-                return search_result.group(1)
-            else:
-                return "N/A"
+            return self._get_file_name_from_content_disposition(content_disposition)
+        else:
+            return "N/A"
 
-        return "N/A"
+    @staticmethod
+    def _get_file_name_from_content_disposition(content_disposition):
+        """Get the file name from the content disposition header.
+        Uses a regex string to match filenames both enclosed or not enclosed in quotes"""
+        search_result = re.search(r"""filename="?([^";\s]+)"?""", content_disposition)
+        if search_result:
+            return search_result.group(1)
+        else:
+            return "N/A"
 
     def _get_event_severity(self, log_level: str) -> str:
         event_map = {

--- a/test_integration/test_service_endpoints.py
+++ b/test_integration/test_service_endpoints.py
@@ -12,7 +12,7 @@ from playwright.sync_api import Playwright
 DELTAS_URL_PATH = "/api/v1/taricdeltas"
 FILES_URL_PATH = "/api/v1/taricfiles"
 
-SEQUENCE_ID = "180251"
+SEQUENCE_ID = 180251
 ENVELOPE_FILE_NAME = "DIT123456.xml"
 MODTIME = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
 DATE = datetime.now().strftime("%Y-%m-%d")
@@ -72,8 +72,7 @@ def api_request_context(
 @pytest.fixture
 def envelope_file_content() -> str:
     """Return the contents of a valid envelope file."""
-    return (
-        """<?xml version="1.0" encoding="UTF-8"?>
+    return """<?xml version="1.0" encoding="UTF-8"?>
         <env:envelope
           xmlns="urn:publicid:-:DGTAXUD:TARIC:MESSAGE:1.0"
           xmlns:env="urn:publicid:-:DGTAXUD:GENERAL:ENVELOPE:1.0"
@@ -81,7 +80,6 @@ def envelope_file_content() -> str:
         >
         <env:transaction id="123"></env:transaction>
         </env:envelope>"""
-    )
 
 
 @pytest.fixture
@@ -166,15 +164,21 @@ def test_get_deltas(
     """Test getting a list of envelopes from the service."""
 
     response = api_request_context.get(f"{DELTAS_URL_PATH}/{DATE}")
-
     assert response.ok
+
+    deltas = response.json()
+    assert deltas[0]["id"] == SEQUENCE_ID
+    assert deltas[0]["issue_date"] == MODTIME
 
 
 def test_get_envelope(
     api_request_context: APIRequestContext,
     posted_envelope: None,
+    envelope_file_content: str,
 ):
     """Test getting a specific envelope from the service."""
 
     response = api_request_context.get(f"{FILES_URL_PATH}/{SEQUENCE_ID}")
     assert response.ok
+
+    assert response.body() == str.encode(envelope_file_content)

--- a/test_integration/test_service_endpoints.py
+++ b/test_integration/test_service_endpoints.py
@@ -70,7 +70,8 @@ def api_request_context(
 
 
 @pytest.fixture
-def envelope_file_content():
+def envelope_file_content() -> str:
+    """Return the contents of a valid envelope file."""
     return (
         """<?xml version="1.0" encoding="UTF-8"?>
         <env:envelope
@@ -85,9 +86,9 @@ def envelope_file_content():
 
 @pytest.fixture
 def posted_envelope(
-    api_request_context,
-    envelope_file_content,
-):
+    api_request_context: APIRequestContext,
+    envelope_file_content: str,
+) -> Generator[None, None, None]:
     """Post an envelope to the service. Used for tests that require an envelope to retrieve."""
     response = api_request_context.post(
         f"{FILES_URL_PATH}/{SEQUENCE_ID}",
@@ -109,7 +110,7 @@ def posted_envelope(
 
 
 def test_root_path(
-    api_request_context,
+    api_request_context: APIRequestContext,
 ):
     """Test that the application's root path responds correctly with a
     `200 OK` response."""
@@ -136,8 +137,8 @@ def test_fail_with_no_api_key(
 
 
 def test_post_envelope(
-    api_request_context,
-    envelope_file_content,
+    api_request_context: APIRequestContext,
+    envelope_file_content: str,
 ):
     """Test posting a valid envelope file to the service."""
 
@@ -159,8 +160,8 @@ def test_post_envelope(
 
 
 def test_get_deltas(
-    api_request_context,
-    posted_envelope,
+    api_request_context: APIRequestContext,
+    posted_envelope: None,
 ):
     """Test getting a list of envelopes from the service."""
 
@@ -170,8 +171,8 @@ def test_get_deltas(
 
 
 def test_get_envelope(
-    api_request_context,
-    posted_envelope,
+    api_request_context: APIRequestContext,
+    posted_envelope: None,
 ):
     """Test getting a specific envelope from the service."""
 

--- a/test_logging/test_logging.py
+++ b/test_logging/test_logging.py
@@ -1,6 +1,8 @@
 import json
 import logging
 from datetime import datetime
+
+import pytest
 from flask import request, Flask, Response
 
 from asim_formatter import ASIMFormatter
@@ -39,15 +41,15 @@ def test_asim_formatter_get_request_dict():
     """Test that get_request_dict returns a correctly formatted dictionary of request data"""
     app = Flask(__name__)
     with app.test_request_context(
-        method="GET",
-        path="/example_route",
-        query_string="param1=value1&param2=value2",
-        headers={
-            "Content-Type": "application/json",
-            "X-Forwarded-For": "1.1.1.1",
-            "X-Amzn-Trace-Id": "123testid",
-        },
-        data='{"key": "value"}',
+            method="GET",
+            path="/example_route",
+            query_string="param1=value1&param2=value2",
+            headers={
+                "Content-Type": "application/json",
+                "X-Forwarded-For": "1.1.1.1",
+                "X-Amzn-Trace-Id": "123testid",
+            },
+            data='{"key": "value"}',
     ):
         request_dict = ASIMFormatter().get_request_dict(request)
 
@@ -76,7 +78,7 @@ def test_asim_formatter_get_response_dict():
         status=200,
         headers={
             "Content-Type": "application/json",
-            "Content-Disposition": "attachment; filename=dummy.rtf",
+            "Content-Disposition": "attachment; filename=dummy.rtf;",
         },
         response='{"key": "value"}',
     )
@@ -112,11 +114,11 @@ def test_asim_formatter_format():
     log_time = datetime.utcfromtimestamp(log_record.created).isoformat()
 
     with app.test_request_context(
-        method="GET",
-        path="/example_route",
-        query_string="param1=value1&param2=value2",
-        headers={"Content-Type": "application/json", "X-Forwarded-For": "1.1.1.1"},
-        data='{"key": "value"}',
+            method="GET",
+            path="/example_route",
+            query_string="param1=value1&param2=value2",
+            headers={"Content-Type": "application/json", "X-Forwarded-For": "1.1.1.1"},
+            data='{"key": "value"}',
     ):
         formatted_log = ASIMFormatter().format(log_record)
         assert formatted_log == json.dumps(
@@ -150,3 +152,18 @@ def test_asim_formatter_format():
                 "HttpStatusCode": response.status_code,
             }
         )
+
+
+@pytest.mark.parametrize("content_disposition, expected_file_name",
+                         [('attachment; filename=example.txt', 'example.txt'),
+                          ('inline; filename="example.txt"', 'example.txt'),
+                          ('attachment; filename="example@file#123.txt"', 'example@file#123.txt'),
+                          ('attachment; filename="example.txt" creation-date="Wed, 12 Feb 1997 16:29:51 -0500"',
+                           'example.txt'),
+                          ('attachment; filename=example.txt creation-date="Wed, 12 Feb 1997 16:29:51 -0500"',
+                           'example.txt'),
+                          ('attachment; filename=example.txt; creation-date="Wed, 12 Feb 1997 16:29:51 -0500"',
+                           'example.txt')])
+def test_get_file_name_from_content_disposition(content_disposition, expected_file_name):
+    file_name = ASIMFormatter()._get_file_name_from_content_disposition(content_disposition)
+    assert file_name == expected_file_name

--- a/test_logging/test_logging.py
+++ b/test_logging/test_logging.py
@@ -7,7 +7,7 @@ from asim_formatter import ASIMFormatter
 
 
 def test_asim_formatter_get_log_dict():
-    """Test that get_log_dict returns a correctly formatted log record """
+    """Test that get_log_dict returns a correctly formatted log record"""
     formatter = ASIMFormatter()
     log_record = logging.LogRecord(
         name=__name__,
@@ -39,15 +39,15 @@ def test_asim_formatter_get_request_dict():
     """Test that get_request_dict returns a correctly formatted dictionary of request data"""
     app = Flask(__name__)
     with app.test_request_context(
-            method="GET",
-            path="/example_route",
-            query_string="param1=value1&param2=value2",
-            headers={
-                "Content-Type": "application/json",
-                "X-Forwarded-For": "1.1.1.1",
-                "X-Amzn-Trace-Id": "123testid",
-            },
-            data='{"key": "value"}',
+        method="GET",
+        path="/example_route",
+        query_string="param1=value1&param2=value2",
+        headers={
+            "Content-Type": "application/json",
+            "X-Forwarded-For": "1.1.1.1",
+            "X-Amzn-Trace-Id": "123testid",
+        },
+        data='{"key": "value"}',
     ):
         request_dict = ASIMFormatter().get_request_dict(request)
 
@@ -112,11 +112,11 @@ def test_asim_formatter_format():
     log_time = datetime.utcfromtimestamp(log_record.created).isoformat()
 
     with app.test_request_context(
-            method="GET",
-            path="/example_route",
-            query_string="param1=value1&param2=value2",
-            headers={"Content-Type": "application/json", "X-Forwarded-For": "1.1.1.1"},
-            data='{"key": "value"}',
+        method="GET",
+        path="/example_route",
+        query_string="param1=value1&param2=value2",
+        headers={"Content-Type": "application/json", "X-Forwarded-For": "1.1.1.1"},
+        data='{"key": "value"}',
     ):
         formatted_log = ASIMFormatter().format(log_record)
         assert formatted_log == json.dumps(

--- a/test_logging/test_logging.py
+++ b/test_logging/test_logging.py
@@ -1,0 +1,152 @@
+import json
+import logging
+from datetime import datetime
+from flask import request, Flask, Response
+
+from asim_formatter import ASIMFormatter
+
+
+def test_asim_formatter_get_log_dict():
+    """Test that get_log_dict returns a correctly formatted log record """
+    formatter = ASIMFormatter()
+    log_record = logging.LogRecord(
+        name=__name__,
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=10,
+        msg="This is a test log message",
+        args=(),
+        exc_info=None,
+    )
+    log_time = datetime.utcfromtimestamp(log_record.created).isoformat()
+
+    log_dict = formatter.get_log_dict(log_record)
+
+    assert log_dict == {
+        "EventMessage": log_record.msg,
+        "EventCount": 1,
+        "EventStartTime": log_time,
+        "EventEndTime": log_time,
+        "EventType": "HTTPsession",
+        "EventSeverity": "Informational",
+        "EventOriginalSeverity": log_record.levelname,  # duplicate of above?
+        "EventSchema": "WebSession",
+        "EventSchemaVersion": "0.2.6",
+    }
+
+
+def test_asim_formatter_get_request_dict():
+    """Test that get_request_dict returns a correctly formatted dictionary of request data"""
+    app = Flask(__name__)
+    with app.test_request_context(
+            method="GET",
+            path="/example_route",
+            query_string="param1=value1&param2=value2",
+            headers={
+                "Content-Type": "application/json",
+                "X-Forwarded-For": "1.1.1.1",
+                "X-Amzn-Trace-Id": "123testid",
+            },
+            data='{"key": "value"}',
+    ):
+        request_dict = ASIMFormatter().get_request_dict(request)
+
+        assert request_dict == {
+            "Url": request.url,
+            "UrlOriginal": request.url,
+            "HttpVersion": request.environ.get("SERVER_PROTOCOL"),
+            "HttpRequestMethod": request.method,
+            "HttpContentType": request.content_type,
+            "HttpContentFormat": request.mimetype,
+            "HttpReferrer": request.referrer,
+            "HttpUserAgent": str(request.user_agent),
+            "HttpRequestXff": request.headers["X-Forwarded-For"],
+            "HttpResponseTime": "N/A",
+            "HttpHost": request.host,
+            "AdditionalFields": {
+                "TraceHeaders": {"X-Amzn-Trace-Id": "123testid"},
+            },
+        }
+
+
+def test_asim_formatter_get_response_dict():
+    """Test that get_response_dict returns a correctly formatted dictionary of response data"""
+
+    response = Response(
+        status=200,
+        headers={
+            "Content-Type": "application/json",
+            "Content-Disposition": "attachment; filename=dummy.rtf",
+        },
+        response='{"key": "value"}',
+    )
+
+    response_dict = ASIMFormatter().get_response_dict(response)
+
+    assert response_dict == {
+        "EventResult": "Success",
+        "EventResultDetails": response.status_code,
+        "FileName": "dummy.rtf",
+        "HttpStatusCode": response.status_code,
+    }
+
+
+def test_asim_formatter_format():
+    """Test full asim formatter including both request and response data"""
+    log_record = logging.LogRecord(
+        name=__name__,
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=10,
+        msg="This is a test log message",
+        args=(),
+        exc_info=None,
+    )
+    response = Response(
+        status=200,
+        headers={"Content-Type": "application/json"},
+        response='{"key": "value"}',
+    )
+    log_record.response = response
+    app = Flask(__name__)
+    log_time = datetime.utcfromtimestamp(log_record.created).isoformat()
+
+    with app.test_request_context(
+            method="GET",
+            path="/example_route",
+            query_string="param1=value1&param2=value2",
+            headers={"Content-Type": "application/json", "X-Forwarded-For": "1.1.1.1"},
+            data='{"key": "value"}',
+    ):
+        formatted_log = ASIMFormatter().format(log_record)
+        assert formatted_log == json.dumps(
+            {
+                "EventMessage": log_record.msg,
+                "EventCount": 1,
+                "EventStartTime": log_time,
+                "EventEndTime": log_time,
+                "EventType": "HTTPsession",
+                "EventSeverity": "Informational",
+                "EventOriginalSeverity": log_record.levelname,  # duplicate of above?
+                "EventSchema": "WebSession",
+                "EventSchemaVersion": "0.2.6",
+                "Url": request.url,
+                "UrlOriginal": request.url,
+                "HttpVersion": request.environ.get("SERVER_PROTOCOL"),
+                "HttpRequestMethod": request.method,
+                "HttpContentType": request.content_type,
+                "HttpContentFormat": request.mimetype,
+                "HttpReferrer": request.referrer,
+                "HttpUserAgent": str(request.user_agent),
+                "HttpRequestXff": request.headers["X-Forwarded-For"],
+                "HttpResponseTime": "N/A",
+                "HttpHost": request.host,
+                "AdditionalFields": {
+                    "TraceHeaders": {"X-Amzn-Trace-Id": None},
+                },
+                "EventResult": "Success",
+                "EventResultDetails": response.status_code,
+                "FileName": "N/A",
+                "HttpStatusCode": response.status_code,
+            }
+        )

--- a/test_logging/test_logging.py
+++ b/test_logging/test_logging.py
@@ -41,15 +41,15 @@ def test_asim_formatter_get_request_dict():
     """Test that get_request_dict returns a correctly formatted dictionary of request data"""
     app = Flask(__name__)
     with app.test_request_context(
-            method="GET",
-            path="/example_route",
-            query_string="param1=value1&param2=value2",
-            headers={
-                "Content-Type": "application/json",
-                "X-Forwarded-For": "1.1.1.1",
-                "X-Amzn-Trace-Id": "123testid",
-            },
-            data='{"key": "value"}',
+        method="GET",
+        path="/example_route",
+        query_string="param1=value1&param2=value2",
+        headers={
+            "Content-Type": "application/json",
+            "X-Forwarded-For": "1.1.1.1",
+            "X-Amzn-Trace-Id": "123testid",
+        },
+        data='{"key": "value"}',
     ):
         request_dict = ASIMFormatter().get_request_dict(request)
 
@@ -114,11 +114,11 @@ def test_asim_formatter_format():
     log_time = datetime.utcfromtimestamp(log_record.created).isoformat()
 
     with app.test_request_context(
-            method="GET",
-            path="/example_route",
-            query_string="param1=value1&param2=value2",
-            headers={"Content-Type": "application/json", "X-Forwarded-For": "1.1.1.1"},
-            data='{"key": "value"}',
+        method="GET",
+        path="/example_route",
+        query_string="param1=value1&param2=value2",
+        headers={"Content-Type": "application/json", "X-Forwarded-For": "1.1.1.1"},
+        data='{"key": "value"}',
     ):
         formatted_log = ASIMFormatter().format(log_record)
         assert formatted_log == json.dumps(
@@ -154,16 +154,30 @@ def test_asim_formatter_format():
         )
 
 
-@pytest.mark.parametrize("content_disposition, expected_file_name",
-                         [('attachment; filename=example.txt', 'example.txt'),
-                          ('inline; filename="example.txt"', 'example.txt'),
-                          ('attachment; filename="example@file#123.txt"', 'example@file#123.txt'),
-                          ('attachment; filename="example.txt" creation-date="Wed, 12 Feb 1997 16:29:51 -0500"',
-                           'example.txt'),
-                          ('attachment; filename=example.txt creation-date="Wed, 12 Feb 1997 16:29:51 -0500"',
-                           'example.txt'),
-                          ('attachment; filename=example.txt; creation-date="Wed, 12 Feb 1997 16:29:51 -0500"',
-                           'example.txt')])
-def test_get_file_name_from_content_disposition(content_disposition, expected_file_name):
-    file_name = ASIMFormatter()._get_file_name_from_content_disposition(content_disposition)
+@pytest.mark.parametrize(
+    "content_disposition, expected_file_name",
+    [
+        ("attachment; filename=example.txt", "example.txt"),
+        ('inline; filename="example.txt"', "example.txt"),
+        ('attachment; filename="example@file#123.txt"', "example@file#123.txt"),
+        (
+            'attachment; filename="example.txt" creation-date="Wed, 12 Feb 1997 16:29:51 -0500"',
+            "example.txt",
+        ),
+        (
+            'attachment; filename=example.txt creation-date="Wed, 12 Feb 1997 16:29:51 -0500"',
+            "example.txt",
+        ),
+        (
+            'attachment; filename=example.txt; creation-date="Wed, 12 Feb 1997 16:29:51 -0500"',
+            "example.txt",
+        ),
+    ],
+)
+def test_get_file_name_from_content_disposition(
+    content_disposition, expected_file_name
+):
+    file_name = ASIMFormatter()._get_file_name_from_content_disposition(
+        content_disposition
+    )
     assert file_name == expected_file_name

--- a/test_logging/test_logging.py
+++ b/test_logging/test_logging.py
@@ -31,7 +31,7 @@ def test_asim_formatter_get_log_dict():
         "EventEndTime": log_time,
         "EventType": "HTTPsession",
         "EventSeverity": "Informational",
-        "EventOriginalSeverity": log_record.levelname,  # duplicate of above?
+        "EventOriginalSeverity": log_record.levelname,
         "EventSchema": "WebSession",
         "EventSchemaVersion": "0.2.6",
     }
@@ -129,7 +129,7 @@ def test_asim_formatter_format():
                 "EventEndTime": log_time,
                 "EventType": "HTTPsession",
                 "EventSeverity": "Informational",
-                "EventOriginalSeverity": log_record.levelname,  # duplicate of above?
+                "EventOriginalSeverity": log_record.levelname,
                 "EventSchema": "WebSession",
                 "EventSchemaVersion": "0.2.6",
                 "Url": request.url,


### PR DESCRIPTION
# [TP2000-1383](https://uktrade.atlassian.net/jira/software/c/projects/TP2000/boards/305?selectedIssue=TP2000-1383) -  Add logging formatting tests and amend file name log record

## Why
Following the platform migration to DBT PaaS we need to format logs in ASIM format. This should be tested to ensure it works properly.

I based the logging for the tariff-api on the IP filter's ASIM formatting as that is also a Flask app. They experienced some bugs with the _get_file_name_ record so I've preemptively made the same fix here.
- IP filter bug fix PR - https://github.com/uktrade/ip-filter/pull/32 

## What
- Adds 4 tests to check the logging formatting is working
- Moves the 'file_name' log record to the response dictionary rather than request dictionary


[TP2000-1383]: https://uktrade.atlassian.net/browse/TP2000-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ