### PR TITLE
TP2000-1451 Replace MD5 hashing algorithm with SHA512

### DIFF
--- a/apifile.py
+++ b/apifile.py
@@ -30,13 +30,13 @@ def modification_date(filepath):
     return datetime.fromtimestamp(t).isoformat()
 
 
-def md5(filepath):
-    hash_md5 = hashlib.md5()
+def sha512(filepath):
+    hash_sha512 = hashlib.sha512()
     with open(filepath, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
-            hash_md5.update(chunk)
+            hash_sha512.update(chunk)
 
-    return hash_md5.hexdigest()
+    return hash_sha512.hexdigest()
 
 
 def file_exists(prefix, file):

--- a/apifiles3.py
+++ b/apifiles3.py
@@ -157,13 +157,12 @@ def get_file_list(prefix):
         return []
 
 
-def md5(filepath):
-    hash_md5 = hashlib.md5()
-
+def sha512(filepath):
+    hash_sha512 = hashlib.sha512()
     for chunk in stream_file(filepath):
-        hash_md5.update(chunk)
+        hash_sha512.update(chunk)
 
-    return hash_md5.hexdigest()
+    return hash_sha512.hexdigest()
 
 
 # Taric file specific functions

--- a/taricapi.py
+++ b/taricapi.py
@@ -37,7 +37,7 @@ from apifiles3 import get_file_list
 from apifiles3 import get_file_size
 from apifiles3 import read_file
 from apifiles3 import file_exists
-from apifiles3 import md5
+from apifiles3 import sha512
 from apifiles3 import modification_date
 from config import (
     API_ROOT,
@@ -169,7 +169,7 @@ def create_index_entry(seq):
         "id": int(seq),
         "issue_date": modification_date(get_taric_filepath(seq)),
         "url": API_ROOT + "taricfiles/" + seq,
-        "md5": md5(get_taric_filepath(seq)),
+        "sha512": sha512(get_taric_filepath(seq)),
         "size": get_file_size(get_taric_filepath(seq)),
     }
     return index_entry

--- a/test_integration/test_service_endpoints.py
+++ b/test_integration/test_service_endpoints.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from hashlib import sha512
 from typing import Generator
 
 import os
@@ -173,6 +174,7 @@ def test_post_envelope(
 def test_get_deltas(
     api_request_context: APIRequestContext,
     posted_envelope: None,
+    envelope_file_content: str,
 ):
     """Test getting a list of envelopes from the service."""
 
@@ -187,6 +189,10 @@ def test_get_deltas(
     assert file_count > 0
     assert deltas[file_count - 1]["id"] == SEQUENCE_ID
     assert deltas[file_count - 1]["issue_date"] == MODTIME
+    assert (
+        deltas[file_count - 1]["sha512"]
+        == sha512(envelope_file_content.encode("utf-8")).hexdigest()
+    )
 
 
 def test_get_envelope(


### PR DESCRIPTION
# [TP2000-1451](https://uktrade.atlassian.net/browse/TP2000-1451) Replace MD5 hashing algorithm with SHA512

## Why
It has been recommended that the hashing algorithm used to generate the signature of uploaded TARIC files be changed to a more secure one.

## What
- Uses SHA512 hashing algorithm to create a checksum of uploaded TARIC files
- Tests that uploaded TARIC files have the expected SHA512 hash

[TP2000-1451]: https://uktrade.atlassian.net/browse/TP2000-1451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ