### PR TITLE
TP2000-1490 Enable Sentry tracing

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 import os
 
 from asim_formatter import ASIMFormatter
-from utils import strtobool
+from utils import as_bool
 from utils import strtolist
 from dbt_copilot_python.utility import is_copilot
 
@@ -52,8 +52,10 @@ S3_ENDPOINT_URL = os.environ.get("S3_ENDPOINT_URL", None)
 
 NUM_PROXIES = int(os.environ.get("NUM_PROXIES", 0))
 SENTRY_DSN = os.environ.get("SENTRY_DSN")
+SENTRY_ENABLE_TRACING = as_bool(os.getenv("SENTRY_ENABLE_TRACING", False))
+SENTRY_TRACES_SAMPLE_RATE = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", 0.0))
 
-REQUIRE_AUTH_FOR_READS = strtobool(os.environ.get("REQUIRE_AUTH_FOR_READS", "true"))
+REQUIRE_AUTH_FOR_READS = as_bool(os.environ.get("REQUIRE_AUTH_FOR_READS", "true"))
 
 ELASTIC_APM_URL = os.environ.get("ELASTIC_APM_URL", None)
 ELASTIC_APM_TOKEN = os.environ.get("ELASTIC_APM_TOKEN", None)

--- a/taricapi.py
+++ b/taricapi.py
@@ -48,6 +48,8 @@ from config import (
     NUM_PROXIES,
     REQUIRE_AUTH_FOR_READS,
     SENTRY_DSN,
+    SENTRY_ENABLE_TRACING,
+    SENTRY_TRACES_SAMPLE_RATE,
     ELASTIC_APM_TOKEN,
     ELASTIC_APM_URL,
     ENVIRONMENT,
@@ -502,6 +504,8 @@ def get_server():
         sentry_sdk.init(
             dsn=SENTRY_DSN,
             integrations=[FlaskIntegration()],
+            enable_tracing=SENTRY_ENABLE_TRACING,
+            traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
         )
 
     @app.after_request

--- a/utils.py
+++ b/utils.py
@@ -1,14 +1,17 @@
 from typing import List, Optional, Union
 
 
-def strtobool(text: Union[str, bool]):
-    if text is True or text is False:
-        return text
+def as_bool(value: Union[str, bool]) -> bool:
+    """
+    Get the boolean value represented by the truthy `value`.
 
-    if text.lower() in ["y", "yes", "on", "true", "1"]:
-        return True
+    :param value str: The value to check
+    :rtype: bool
+    """
+    if not value:
+        return False
 
-    return False
+    return str(value).lower() in ["y", "yes", "on", "t", "true", "1"]
 
 
 def strtolist(text: Optional[str]) -> List[str]:


### PR DESCRIPTION
# TP2000-1490 Enable Sentry tracing
<!---
 * Include the JIRA ticket number, eg TP-123, to automatically link.
 * Use 50 characters maximum.
 * Do not end with a full-stop.
--->

## Why
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Use as many lines as you like.
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions or deliberately ignored edge-cases.
--->
Migration to DBT Platform moves performance telemetry capture from Grafana to Sentry.


## What
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Explain like I'm 5.
 * Use pictures if you can.
--->
Support enabling Sentry tracing and trace sampling rate via the environment variables `SENTRY_ENABLE_TRACING` and `SENTRY_TRACES_SAMPLE_RATE`, respectively. The values loaded from these variables (with sensible default parameters to support current platform) are passed into the `sentry_sdk.init()` function via `enable_tracing` and `traces_sample_rate`.


<!---
Optionally let reviewers know they need to run migrations or update dependencies before
testing by adding the following section:
--->
## Checklist
- Requires migrations? No
- Requires dependency updates? No

<!---
Links to relevant material
See: [Description](https://example.com/...)
--->
