### PR TITLE
Bump versions of certifi and zipp packages.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ blinker==1.4              # via -r requirements.txt, elastic-apm, sentry-sdk
 boto3==1.17.97            # via -r requirements.txt
 botocore==1.20.97         # via -r requirements.txt, boto3, s3transfer
 celery==5.4.0             # via -r requirements.txt, dbt-copilot-python
-certifi==2023.7.22        # via -r requirements.txt, elastic-apm, requests, sentry-sdk
+certifi==2024.7.4         # via -r requirements.txt, elastic-apm, requests, sentry-sdk
 charset-normalizer==3.1.0  # via -r requirements.txt, requests
 click-didyoumean==0.3.1   # via -r requirements.txt, celery
 click-plugins==1.1.1      # via -r requirements.txt, celery
@@ -94,7 +94,7 @@ vine==5.1.0               # via -r requirements.txt, amqp, celery, kombu
 wcwidth==0.2.13           # via -r requirements.txt, prompt-toolkit
 werkzeug==3.0.3           # via -r requirements.txt, flask
 wrapt==1.16.0             # via -r requirements.txt, astroid, deprecated, opentelemetry-instrumentation
-zipp==3.17.0              # via -r requirements.txt, importlib-metadata
+zipp==3.19.1              # via -r requirements.txt, importlib-metadata
 zope.event==5.0           # via -r requirements.txt, gevent
 zope.interface==6.1       # via -r requirements.txt, gevent
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ blinker==1.4              # via -r requirements.txt, elastic-apm, sentry-sdk
 boto3==1.17.97            # via -r requirements.txt
 botocore==1.20.97         # via -r requirements.txt, boto3, s3transfer
 celery==5.4.0             # via -r requirements.txt, dbt-copilot-python
-certifi==2024.7.4         # via -r requirements.txt, elastic-apm, requests, sentry-sdk
+certifi==2024.8.30        # via -r requirements.txt, elastic-apm, requests, sentry-sdk
 charset-normalizer==3.1.0  # via -r requirements.txt, requests
 click-didyoumean==0.3.1   # via -r requirements.txt, celery
 click-plugins==1.1.1      # via -r requirements.txt, celery

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 Boto3==1.17.97
-certifi==2024.07.04
+certifi==2024.8.30
 click==8.1.3
 dbt-copilot-python==0.2.1
 ecs-logging==0.5.0

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 Boto3==1.17.97
-certifi==2023.7.22
+certifi==2024.07.04
 click==8.1.3
 dbt-copilot-python==0.2.1
 ecs-logging==0.5.0
@@ -18,3 +18,4 @@ requests==2.32.0
 sentry-sdk[flask]==2.13.0
 urllib3==1.26.19
 Werkzeug==3.0.3
+zipp==3.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ blinker==1.4              # via elastic-apm, sentry-sdk
 boto3==1.17.97            # via -r requirements.in
 botocore==1.20.97         # via boto3, s3transfer
 celery==5.4.0             # via dbt-copilot-python
-certifi==2023.7.22        # via -r requirements.in, elastic-apm, requests, sentry-sdk
+certifi==2024.7.4         # via -r requirements.in, elastic-apm, requests, sentry-sdk
 charset-normalizer==3.1.0  # via requests
 click-didyoumean==0.3.1   # via celery
 click-plugins==1.1.1      # via celery
@@ -63,7 +63,7 @@ vine==5.1.0               # via amqp, celery, kombu
 wcwidth==0.2.13           # via prompt-toolkit
 werkzeug==3.0.3           # via -r requirements.in, flask
 wrapt==1.16.0             # via deprecated, opentelemetry-instrumentation
-zipp==3.17.0              # via importlib-metadata
+zipp==3.19.1              # via -r requirements.in, importlib-metadata
 zope.event==5.0           # via gevent
 zope.interface==6.1       # via gevent
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ blinker==1.4              # via elastic-apm, sentry-sdk
 boto3==1.17.97            # via -r requirements.in
 botocore==1.20.97         # via boto3, s3transfer
 celery==5.4.0             # via dbt-copilot-python
-certifi==2024.7.4         # via -r requirements.in, elastic-apm, requests, sentry-sdk
+certifi==2024.8.30        # via -r requirements.in, elastic-apm, requests, sentry-sdk
 charset-normalizer==3.1.0  # via requests
 click-didyoumean==0.3.1   # via celery
 click-plugins==1.1.1      # via celery


### PR DESCRIPTION
Bump versions of certifi and zipp to resolve Dependabot alerts.