### PR TITLE
Dependabot alert fix bump jinja

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -39,7 +39,7 @@ iniconfig==2.0.0          # via pytest
 ipy==0.83                 # via -r requirements.txt
 isort==4.3.21             # via pylint
 itsdangerous==2.1.2       # via -r requirements.txt, flask
-jinja2==3.1.4             # via -r requirements.txt, flask
+jinja2==3.1.5             # via -r requirements.txt, flask
 jmespath==0.10.0          # via -r requirements.txt, boto3, botocore
 kombu==5.3.7              # via -r requirements.txt, celery
 lazy-object-proxy==1.4.3  # via astroid

--- a/requirements.in
+++ b/requirements.in
@@ -17,5 +17,5 @@ python-dateutil>=2.8.2
 requests==2.32.0
 sentry-sdk[flask]==2.13.0
 urllib3==1.26.19
-Werkzeug==3.0.3
+Werkzeug==3.0.6
 zipp==3.19.1

--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,7 @@ greenlet==3.0.3
 idna==3.7
 IPy==0.83
 itsdangerous==2.1.2
-Jinja2==3.1.4
+Jinja2==3.1.5
 lxml==4.9.1
 MarkupSafe==2.1.2
 python-dateutil>=2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ idna==3.7                 # via -r requirements.in, requests
 importlib-metadata==6.8.0  # via flask, opentelemetry-api
 ipy==0.83                 # via -r requirements.in
 itsdangerous==2.1.2       # via -r requirements.in, flask
-jinja2==3.1.4             # via -r requirements.in, flask
+jinja2==3.1.5             # via -r requirements.in, flask
 jmespath==0.10.0          # via boto3, botocore
 kombu==5.3.7              # via celery
 lxml==4.9.1               # via -r requirements.in


### PR DESCRIPTION
Dependabot-generated PRs are unavailable on this repo because it uses pip-tools pip-compile.

This PR bumps Jinja2 version to fix dependabot alerts and pins Werkzeug to avoid its version from being reverted to a previous version.